### PR TITLE
fix: adjust for cmake 4.0

### DIFF
--- a/leveldbstatic/prelude.nim
+++ b/leveldbstatic/prelude.nim
@@ -12,7 +12,9 @@ const
       "-G\"MSYS Makefiles\" -DCMAKE_BUILD_TYPE=Release -DLEVELDB_BUILD_BENCHMARKS=OFF"
     else:
       "-DCMAKE_BUILD_TYPE=Release -DLEVELDB_BUILD_BENCHMARKS=OFF"
-  
+
+  LevelDbCMakeCommonFlags = " -DCMAKE_POLICY_VERSION_MINIMUM=3.31"
+
   LevelDbDir {.strdefine.} = $(root/"vendor")
   buildDir = $(root/"build")
 
@@ -29,7 +31,7 @@ proc buildLevelDb() =
   discard gorge "rm -rf " & buildDir
   discard gorge "mkdir -p " & buildDir
 
-  let cmd = "cmake -S \"" & LevelDbDir & "\" -B \"" & buildDir & "\" " & LevelDbCMakeFlags
+  let cmd = "cmake -S \"" & LevelDbDir & "\" -B \"" & buildDir & "\" " & LevelDbCMakeFlags & LevelDbCMakeCommonFlags
   echo "\nBuilding LevelDB: " & cmd
   let (output, exitCode) = gorgeEx cmd
   if exitCode != 0:

--- a/leveldbstatic/raw.nim
+++ b/leveldbstatic/raw.nim
@@ -12,7 +12,9 @@ const
       "-G\"MSYS Makefiles\" -DCMAKE_BUILD_TYPE=Release -DLEVELDB_BUILD_BENCHMARKS=OFF"
     else:
       "-DCMAKE_BUILD_TYPE=Release -DLEVELDB_BUILD_BENCHMARKS=OFF"
-  
+
+  LevelDbCMakeCommonFlags = " -DCMAKE_POLICY_VERSION_MINIMUM=3.31"
+
   LevelDbDir {.strdefine.} = $(root/"vendor")
   buildDir = $(root/"build")
 
@@ -29,7 +31,7 @@ proc buildLevelDb() =
   discard gorge "rm -rf " & buildDir
   discard gorge "mkdir -p " & buildDir
 
-  let cmd = "cmake -S \"" & LevelDbDir & "\" -B \"" & buildDir & "\" " & LevelDbCMakeFlags
+  let cmd = "cmake -S \"" & LevelDbDir & "\" -B \"" & buildDir & "\" " & LevelDbCMakeFlags & LevelDbCMakeCommonFlags
   echo "\nBuilding LevelDB: " & cmd
   let (output, exitCode) = gorgeEx cmd
   if exitCode != 0:


### PR DESCRIPTION
This PR intends to a fix LevelDB builds with recently released (March 28, 2025) - [CMake 4.0.0 available for download
](https://www.kitware.com/cmake-4-0-0-available-for-download/).

GitHub already made pre-releases(20250330), on which builds are failing and we are using the following for [nim-codex](https://github.com/codex-storage/nim-codex)
 - [Windows Server 2022 (20250330) Image Update](https://github.com/actions/runner-images/releases/tag/win22%2F20250330.1) Pre-release
 - [Ubuntu 24.04 (20250330) Image Update](https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250330.1) Pre-release
 - [macOS 13 (20250331) Image Update](https://github.com/actions/runner-images/releases/tag/macos-13%2F20250331.901) Pre-release
 
<img width="1203" alt="Screenshot 2025-03-31 at 20 26 38" src="https://github.com/user-attachments/assets/b99751bb-9adb-4adb-859d-2ba6cbe5151b" />
